### PR TITLE
Introduce painting classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,6 +229,226 @@
         isMobile = true
       }
 
+      class Painting {
+        constructor(data, x, y, z, rotation) {
+          this.data = data
+          this.x = x
+          this.y = y
+          this.z = z
+          this.rotation = rotation
+        }
+
+        drawContent(context, texture) {}
+
+        getUserData(material) {
+          return { originalMaterial: material.clone() }
+        }
+
+        create() {
+          const frameGeometry = new THREE.BoxGeometry(
+            CONFIG.PAINTING.WIDTH + 0.2,
+            CONFIG.PAINTING.HEIGHT + 0.2,
+            CONFIG.PAINTING.FRAME_THICKNESS
+          )
+          const frameMaterial = new THREE.MeshStandardMaterial({
+            color: CONFIG.COLORS.FRAME,
+            roughness: 0.4,
+            metalness: 0.7
+          })
+          const frame = new THREE.Mesh(frameGeometry, frameMaterial)
+          frame.castShadow = true
+          frame.receiveShadow = true
+          frame.position.set(this.x, this.y, this.z)
+          frame.rotation.y = this.rotation
+          scene.add(frame)
+
+          const canvas = document.createElement('canvas')
+          canvas.width = CONFIG.PAINTING.CANVAS_WIDTH
+          canvas.height = CONFIG.PAINTING.CANVAS_HEIGHT
+          const context = canvas.getContext('2d')
+          context.fillStyle = CONFIG.COLORS.BACKGROUND_DARK
+          context.fillRect(0, 0, canvas.width, canvas.height)
+          const texture = new THREE.CanvasTexture(canvas)
+          this.drawContent(context, texture)
+
+          const paintingGeometry = new THREE.BoxGeometry(
+            CONFIG.PAINTING.WIDTH,
+            CONFIG.PAINTING.HEIGHT,
+            0.05
+          )
+          const paintingMaterial = new THREE.MeshStandardMaterial({
+            map: texture,
+            roughness: 0.5,
+            metalness: 0.1,
+            emissive: 0x666666,
+            emissiveMap: texture
+          })
+          const painting = new THREE.Mesh(paintingGeometry, paintingMaterial)
+          painting.castShadow = true
+          painting.receiveShadow = true
+          painting.position.set(this.x, this.y, this.z)
+
+          if (this.rotation === 0) painting.position.z += 0.06
+          else if (this.rotation === Math.PI) painting.position.z -= 0.06
+          else if (this.rotation === Math.PI / 2) painting.position.x += 0.06
+          else if (this.rotation === -Math.PI / 2) painting.position.x -= 0.06
+
+          painting.rotation.y = this.rotation
+          painting.userData = this.getUserData(paintingMaterial)
+          scene.add(painting)
+          paintingMeshes.push(painting)
+        }
+      }
+
+      class RepoPainting extends Painting {
+        drawContent(context) {
+          const repo = this.data
+          context.fillStyle = CONFIG.COLORS.TEXT
+          const repoName = repo.name
+          context.font = 'bold 36px Arial'
+          const nameWidth = context.measureText(repoName).width
+          if (nameWidth > context.canvas.width - 40) context.font = 'bold 24px Arial'
+          context.textAlign = 'center'
+          context.fillText(repoName, context.canvas.width / 2, 50)
+          if (repo.description) {
+            context.font = '18px Arial'
+            wrapText(
+              context,
+              repo.description,
+              context.canvas.width / 2,
+              100,
+              context.canvas.width - 40,
+              25
+            )
+          }
+          context.font = '16px Arial'
+          context.fillText(
+            `⭐ Stars: ${repo.stargazers_count} | 🍴 Forks: ${repo.forks_count}`,
+            context.canvas.width / 2,
+            context.canvas.height - 80
+          )
+          if (repo.language) {
+            const langColor = CONFIG.LANGUAGE_COLORS[repo.language] || '#888888'
+            context.fillStyle = langColor
+            context.beginPath()
+            context.arc(
+              context.canvas.width / 2 - 50,
+              context.canvas.height - 40,
+              8,
+              0,
+              2 * Math.PI
+            )
+            context.fill()
+            context.fillStyle = CONFIG.COLORS.TEXT
+            context.fillText(
+              repo.language,
+              context.canvas.width / 2,
+              context.canvas.height - 40
+            )
+          }
+          context.font = '14px Arial'
+          const updated = new Date(repo.updated_at).toLocaleDateString()
+          context.fillText(
+            `Updated: ${updated}`,
+            context.canvas.width / 2,
+            context.canvas.height - 15
+          )
+        }
+
+        getUserData(material) {
+          return {
+            url: this.data.html_url,
+            name: this.data.name,
+            originalMaterial: material.clone()
+          }
+        }
+      }
+
+      class SpotifyPainting extends Painting {
+        drawContent(context, texture) {
+          const track = this.data
+          const albumArt = new Image()
+          albumArt.crossOrigin = 'Anonymous'
+          albumArt.onload = function () {
+            context.drawImage(
+              albumArt,
+              (context.canvas.width - CONFIG.PAINTING.ALBUM_ART_SIZE) / 2,
+              30,
+              CONFIG.PAINTING.ALBUM_ART_SIZE,
+              CONFIG.PAINTING.ALBUM_ART_SIZE
+            )
+            context.fillStyle = CONFIG.COLORS.TEXT
+            context.font = 'bold 32px Arial'
+            context.textAlign = 'center'
+            context.fillText(
+              track.name,
+              context.canvas.width / 2,
+              CONFIG.PAINTING.ALBUM_ART_SIZE + 60
+            )
+            context.font = '18px Arial'
+            context.fillText(
+              track.artists,
+              context.canvas.width / 2,
+              CONFIG.PAINTING.ALBUM_ART_SIZE + 100
+            )
+            context.fillText(
+              track.album,
+              context.canvas.width / 2,
+              CONFIG.PAINTING.ALBUM_ART_SIZE + 130
+            )
+            texture.needsUpdate = true
+          }
+          albumArt.src = track.albumArt
+        }
+
+        getUserData(material) {
+          return {
+            url: this.data.spotifyUrl,
+            name: `${this.data.name} by ${this.data.artists}`,
+            originalMaterial: material.clone(),
+            isSpotify: true
+          }
+        }
+      }
+
+      class ResumePainting extends Painting {
+        drawContent(context) {
+          const section = this.data
+          const lines = wrapTextLines(
+            context,
+            section.text,
+            context.canvas.width - 40,
+            25,
+            5
+          )
+          const titleHeight = 32
+          const gapAfterTitle = 20
+          const totalHeight = titleHeight + gapAfterTitle + lines.length * 25
+          const startY = (context.canvas.height - totalHeight) / 2
+          context.fillStyle = CONFIG.COLORS.TEXT
+          context.font = 'bold 32px Arial'
+          context.textAlign = 'center'
+          context.textBaseline = 'top'
+          context.fillText(section.title, context.canvas.width / 2, startY)
+          context.font = '18px Arial'
+          let y = startY + titleHeight + gapAfterTitle
+          for (const line of lines) {
+            context.fillText(line, context.canvas.width / 2, y)
+            y += 25
+          }
+          context.textBaseline = 'alphabetic'
+        }
+
+        getUserData(material) {
+          return {
+            url: this.data.url,
+            name: this.data.title,
+            originalMaterial: material.clone(),
+            isResume: true
+          }
+        }
+      }
+
       async function loadRepositories() {
         try {
           const repoResponse = await fetch(
@@ -661,229 +881,19 @@
           }
         }
       }
-
-      function createPainting(
-        data,
-        x,
-        y,
-        z,
-        rotation,
-        isSpotify = false,
-        isResume = false
-      ) {
-        const frameGeometry = new THREE.BoxGeometry(
-          CONFIG.PAINTING.WIDTH + 0.2,
-          CONFIG.PAINTING.HEIGHT + 0.2,
-          CONFIG.PAINTING.FRAME_THICKNESS
-        )
-        const frameMaterial = new THREE.MeshStandardMaterial({
-          color: CONFIG.COLORS.FRAME,
-          roughness: 0.4,
-          metalness: 0.7
-        })
-        const frame = new THREE.Mesh(frameGeometry, frameMaterial)
-        frame.castShadow = true
-        frame.receiveShadow = true
-        frame.position.set(x, y, z)
-        frame.rotation.y = rotation
-        scene.add(frame)
-
-        const canvas = document.createElement('canvas')
-        canvas.width = CONFIG.PAINTING.CANVAS_WIDTH
-        canvas.height = CONFIG.PAINTING.CANVAS_HEIGHT
-        const context = canvas.getContext('2d')
-
-        context.fillStyle = CONFIG.COLORS.BACKGROUND_DARK
-        context.fillRect(0, 0, canvas.width, canvas.height)
-
-        const texture = new THREE.CanvasTexture(canvas)
-
+      function createPainting(data, x, y, z, rotation, isSpotify = false, isResume = false) {
+        let painting
         if (isSpotify) {
-          const track = data
-
-          const albumArt = new Image()
-          albumArt.crossOrigin = 'Anonymous'
-
-          albumArt.onload = function () {
-            context.drawImage(
-              albumArt,
-              (canvas.width - CONFIG.PAINTING.ALBUM_ART_SIZE) / 2,
-              30,
-              CONFIG.PAINTING.ALBUM_ART_SIZE,
-              CONFIG.PAINTING.ALBUM_ART_SIZE
-            )
-
-            context.fillStyle = CONFIG.COLORS.TEXT
-            context.font = 'bold 32px Arial'
-            context.textAlign = 'center'
-            context.fillText(
-              track.name,
-              canvas.width / 2,
-              CONFIG.PAINTING.ALBUM_ART_SIZE + 60
-            )
-
-            context.font = '18px Arial'
-            context.fillText(
-              track.artists,
-              canvas.width / 2,
-              CONFIG.PAINTING.ALBUM_ART_SIZE + 100
-            )
-
-            context.fillText(
-              track.album,
-              canvas.width / 2,
-              CONFIG.PAINTING.ALBUM_ART_SIZE + 130
-            )
-
-            texture.needsUpdate = true
-          }
-
-          albumArt.src = track.albumArt
+          painting = new SpotifyPainting(data, x, y, z, rotation)
         } else if (isResume) {
-          const section = data
-
-          const lines = wrapTextLines(
-            context,
-            section.text,
-            canvas.width - 40,
-            25,
-            5
-          )
-
-          const titleHeight = 32
-          const gapAfterTitle = 20
-          const totalHeight = titleHeight + gapAfterTitle + lines.length * 25
-          const startY = (canvas.height - totalHeight) / 2
-
-          context.fillStyle = CONFIG.COLORS.TEXT
-          context.font = 'bold 32px Arial'
-          context.textAlign = 'center'
-          context.textBaseline = 'top'
-          context.fillText(section.title, canvas.width / 2, startY)
-
-          context.font = '18px Arial'
-          let y = startY + titleHeight + gapAfterTitle
-          for (const line of lines) {
-            context.fillText(line, canvas.width / 2, y)
-            y += 25
-          }
-          context.textBaseline = 'alphabetic'
+          painting = new ResumePainting(data, x, y, z, rotation)
         } else {
-          const repo = data
-
-          context.fillStyle = CONFIG.COLORS.TEXT
-
-          const repoName = repo.name
-          context.font = 'bold 36px Arial'
-          const nameWidth = context.measureText(repoName).width
-          if (nameWidth > canvas.width - 40) {
-            context.font = 'bold 24px Arial'
-          }
-          context.textAlign = 'center'
-          context.fillText(repoName, canvas.width / 2, 50)
-
-          if (repo.description) {
-            context.font = '18px Arial'
-            wrapText(
-              context,
-              repo.description,
-              canvas.width / 2,
-              100,
-              canvas.width - 40,
-              25
-            )
-          }
-
-          context.font = '16px Arial'
-          context.fillText(
-            `⭐ Stars: ${repo.stargazers_count} | 🍴 Forks: ${repo.forks_count}`,
-            canvas.width / 2,
-            canvas.height - 80
-          )
-
-          if (repo.language) {
-            const langColor = CONFIG.LANGUAGE_COLORS[repo.language] || '#888888'
-
-            context.fillStyle = langColor
-            context.beginPath()
-            context.arc(
-              canvas.width / 2 - 50,
-              canvas.height - 40,
-              8,
-              0,
-              2 * Math.PI
-            )
-            context.fill()
-
-            context.fillStyle = CONFIG.COLORS.TEXT
-            context.fillText(
-              repo.language,
-              canvas.width / 2,
-              canvas.height - 40
-            )
-          }
-
-          context.font = '14px Arial'
-          const updated = new Date(repo.updated_at).toLocaleDateString()
-          context.fillText(
-            `Updated: ${updated}`,
-            canvas.width / 2,
-            canvas.height - 15
-          )
+          painting = new RepoPainting(data, x, y, z, rotation)
         }
-
-        const paintingGeometry = new THREE.BoxGeometry(
-          CONFIG.PAINTING.WIDTH,
-          CONFIG.PAINTING.HEIGHT,
-          0.05
-        )
-
-        const paintingMaterial = new THREE.MeshStandardMaterial({
-          map: texture,
-          roughness: 0.5,
-          metalness: 0.1,
-          emissive: 0x666666,
-          emissiveMap: texture
-        })
-
-        const painting = new THREE.Mesh(paintingGeometry, paintingMaterial)
-        painting.castShadow = true
-        painting.receiveShadow = true
-        painting.position.set(x, y, z)
-
-        if (rotation === 0) painting.position.z += 0.06
-        else if (rotation === Math.PI) painting.position.z -= 0.06
-        else if (rotation === Math.PI / 2) painting.position.x += 0.06
-        else if (rotation === -Math.PI / 2) painting.position.x -= 0.06
-
-        painting.rotation.y = rotation
-
-        if (isSpotify) {
-          painting.userData = {
-            url: data.spotifyUrl,
-            name: `${data.name} by ${data.artists}`,
-            originalMaterial: paintingMaterial.clone(),
-            isSpotify: true
-          }
-        } else if (isResume) {
-          painting.userData = {
-            url: data.url,
-            name: data.title,
-            originalMaterial: paintingMaterial.clone(),
-            isResume: true
-          }
-        } else {
-          painting.userData = {
-            url: data.html_url,
-            name: data.name,
-            originalMaterial: paintingMaterial.clone()
-          }
-        }
-
-        scene.add(painting)
-
-        paintingMeshes.push(painting)
+        painting.create()
       }
+
+
 
       function wrapText(context, text, x, y, maxWidth, lineHeight) {
         const words = text.split(' ')


### PR DESCRIPTION
## Summary
- refactor painting creation into `Painting` base class
- implement `RepoPainting`, `SpotifyPainting`, and `ResumePainting` subclasses
- create paintings via the new classes for easier extension

## Testing
- `git status --short`