### PR TITLE
fix: prevent opener access when opening exhibits

### DIFF
--- a/index.html
+++ b/index.html
@@ -984,7 +984,7 @@
             ? camera.position.z
             : controls.getObject().position.z
 
-          window.open(object.userData.url, '_blank')
+          window.open(object.userData.url, '_blank', 'noopener,noreferrer')
         }
       }
 


### PR DESCRIPTION
## Summary
- update `window.open` call in the exhibit click handler to use
  `'noopener,noreferrer'` when opening a new tab

## Testing
- `git status --short`